### PR TITLE
タスクの文字数を制限する

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,5 @@
 class Task < ApplicationRecord
-  validates :content, presence: true
+  validates :content, presence: true, length: { maximum: 26 }
   attribute :priority, :string, default: '未設定'
 
   belongs_to :user


### PR DESCRIPTION
#What
タスクの文字数を制限する

#Why
あまりにも長いタスク文章を制限するため